### PR TITLE
Adds HAProxy LXC container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 Usage
 -----
 
-This repository sets up 3 LXC containers containing a Galera cluster, and
-can run a set of benchmarks against the Galera cluster.
+This repository sets up 3 LXC containers containing a Galera cluster, a
+container running HAProxy, and can run a set of benchmarks against the Galera
+cluster.
 
 To set up the LXC containers, run the create-env.sh script after pulling
 this repository:
@@ -11,22 +12,28 @@ this repository:
 git clone git@github.com:jaypipes/galera-update-bench
 cd galera-update-bench
 ./scripts/create-env.sh
-pushd ansible
-ansible-playbook -i hosts setup-galera.yml
-popd
 ```
 
-Once completed, you can see the IP addresses the three LXC containers
-have using `lxc-ls --fancy`:
+Output of the `create-env.sh` script should look something like the following:
 
 ```
-jaypipes@spearmint$ sudo lxc-ls --fancy
-NAME            STATE    IPV4        IPV6  AUTOSTART  
-----------------------------------------------------
-base-container  STOPPED  -           -     NO         
-galera1         RUNNING  10.0.3.96   -     NO         
-galera2         RUNNING  10.0.3.172  -     NO         
-galera3         RUNNING  10.0.3.143  -     NO
+jaypipes@minty:~/repos/galera-update-bench$ ./scripts/create-env.sh 
+[sudo] password for jaypipes: 
+Started haproxy container...
+Started Galera cluster node container #1...
+Started Galera cluster node container #2...
+Started Galera cluster node container #3...
+NAME            STATE    IPV4        IPV6  GROUPS  AUTOSTART  
+------------------------------------------------------------
+base-container  STOPPED  -           -     -       NO         
+galera1         RUNNING  10.0.3.245  -     -       NO         
+galera2         RUNNING  10.0.3.19   -     -       NO         
+galera3         RUNNING  10.0.3.101  -     -       NO         
+haproxy         RUNNING  10.0.3.74   -     -       NO         
+Added host keys for haproxy cluster node container...
+Added host keys for Galera cluster node container #1...
+Added host keys for Galera cluster node container #2...
+Added host keys for Galera cluster node container #3...
 ```
 
 Note that the `create-env.sh` script automatically adds the host keys
@@ -34,7 +41,7 @@ for each of the LXC containers to your SSH `known_hosts` file, so to
 log into one of the Galera LXC nodes, simply SSH to it as the ubuntu user:
 
 ```
-jaypipes@spearmint$ ssh ubuntu@10.0.3.96
+jaypipes@spearmint$ ssh ubuntu@10.0.3.245
 Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-37-generic x86_64)
 
  * Documentation:  https://help.ubuntu.com/
@@ -43,7 +50,7 @@ Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-37-generic x86_64)
 
   System load:  0.33             Processes:           26
   Usage of /:   2.0% of 1.61TB   Users logged in:     0
-  Memory usage: 35%              IP address for eth0: 10.0.3.96
+  Memory usage: 35%              IP address for eth0: 10.0.3.245
   Swap usage:   0%
 
   Graph this data and manage this system at:
@@ -54,6 +61,15 @@ Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-37-generic x86_64)
 
 
 Last login: Sun Feb 22 20:30:03 2015 from 10.0.3.1
+```
+
+Once the LXC containers are ready, you can install the Galera and HAProxy
+software within the containers using the Ansible playbooks:
+
+```
+pushd ansible
+ansible-playbook -i hosts site.yml
+popd
 ```
 
 You may execute commands, including checking for the status of

--- a/ansible/roles/galera/defaults/main.yml
+++ b/ansible/roles/galera/defaults/main.yml
@@ -20,22 +20,6 @@ galera:
   - software-properties-common
   - debconf-utils
 
-# The package name for mariaDB is set as a variable
-# so that it can be used in debconf later in the
-# "  common" role.
-  mariadb_server_package: "mariadb-galera-server-5.5"
-
-# NB This is specifically   packages as these packages only get installed
-# during the galera play - this is because of the preseed task and the service
-# startup control used when installing mariadb-galera-server and galera.
-  apt_packages:
-  - mariadb-client
-  - "{{   mariadb_server_package }}"
-  - galera
-  - rsync
-  - xtrabackup
-  - socat
-
   debconf_items:
   - question: "mysql-server/root_password"
     name: "{{   mariadb_server_package }}"

--- a/ansible/roles/galera/templates/wsrep.cnf.j2
+++ b/ansible/roles/galera/templates/wsrep.cnf.j2
@@ -33,7 +33,7 @@ max_connect_errors = 999999999999
 
 wsrep_provider = /usr/lib/galera3/libgalera_smm.so
 wsrep_cluster_address = "gcomm://{% for host in groups['galera'] %}{% if not loop.first %},{% endif %}{{ hostvars[host]["ansible_eth0"]["ipv4"]["address"] }}{% endfor %}"
-wsrep_slave_threads = 2
+wsrep_slave_threads = 3
 wsrep_cluster_name = galera_bench
 wsrep_sst_method = xtrabackup-v2
 wsrep_node_name = {{ ansible_hostname }}

--- a/ansible/roles/haproxy/handlers/main.yml
+++ b/ansible/roles/haproxy/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: restart haproxy
+  service:
+    name: haproxy
+    state: restarted

--- a/ansible/roles/haproxy/tasks/main.yml
+++ b/ansible/roles/haproxy/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+
+- name: install haproxy package
+  sudo: true
+  apt:
+    pkg: "{{ item }}"
+    state: installed
+    force: yes
+  with_items:
+    - haproxy
+    - socat
+
+- name: render haproxy configuration file
+  sudo: true
+  template:
+    src: haproxy.cfg.j2
+    dest: /etc/haproxy/haproxy.cfg
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart haproxy
+
+- name: render haproxy defaults
+  sudo: true
+  template:
+    src: haproxy_default.j2
+    dest: /etc/default/haproxy
+    owner: root
+    group: root
+    mode: 0644
+
+- name: start haproxy
+  sudo: true
+  service:
+    name: haproxy
+    state: restarted

--- a/ansible/roles/haproxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/haproxy/templates/haproxy.cfg.j2
@@ -1,0 +1,56 @@
+global
+    log 127.0.0.1 local0
+    log 127.0.0.1 local1 notice
+    maxconn 65000
+    daemon
+    stats socket /tmp/haproxy.sock
+
+defaults
+    log global
+    mode tcp
+    option tcplog
+    option dontlognull
+    retries 3
+    option redispatch
+    timeout client 28801000
+    timeout connect 28810000
+    timeout server 28820000
+
+frontend stats-front
+    bind *:8080
+    mode http
+    default_backend stats-back
+
+backend stats-back
+    mode http
+    balance roundrobin
+    stats uri /haproxy/stats
+    stats auth galera:galera
+
+frontend galera-front
+    bind *:3307
+    mode tcp
+    default_backend galera-back
+
+frontend galera-single-writer-front
+    bind *:3306
+    mode tcp
+    default_backend galera-single-writer-back
+
+backend galera-back
+    mode tcp
+    balance leastconn
+    option httpchk
+    default-server on-marked-down shutdown-sessions on-marked-up shutdown-backup-sessions
+{% for host in groups['galera'] %}
+    server galera{{ loop.index }} {{ hostvars[host]["ansible_eth0"]["ipv4"]["address"] }}:3306 maxconn 20000
+{% endfor %}
+
+backend galera-single-writer-back
+    mode tcp
+    balance leastconn
+    option httpchk
+    default-server on-marked-down shutdown-sessions on-marked-up shutdown-backup-sessions
+{% for host in groups['galera'] %}
+    server galera{{ loop.index }} {{ hostvars[host]["ansible_eth0"]["ipv4"]["address"] }}:3306 maxconn 20000 {% if not loop.first %} backup{% endif %}
+{% endfor %}

--- a/ansible/roles/haproxy/templates/haproxy_default.j2
+++ b/ansible/roles/haproxy/templates/haproxy_default.j2
@@ -1,0 +1,4 @@
+# Set ENABLED to 1 if you want the init script to start haproxy.
+ENABLED=1
+# Add extra flags here.
+#EXTRAOPTS="-de -m 16"

--- a/ansible/setup-haproxy.yml
+++ b/ansible/setup-haproxy.yml
@@ -1,0 +1,6 @@
+---
+- hosts: haproxy
+  gather_facts: true
+  remote_user: ubuntu
+  roles:
+    - haproxy

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -1,0 +1,3 @@
+---
+- include: setup-galera.yml
+- include: setup-haproxy.yml

--- a/scripts/teardown-env.sh
+++ b/scripts/teardown-env.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
-# NOTE(jaypipes): This only tested on Ubuntu 14.04.
+# NOTE(jaypipes): This tested on Ubuntu 14.04 and 14.10.
 
 set -e
 
-echo "Stopping Galera containers..."
+echo "Stopping containers..."
 
 sudo lxc-stop -n galera1
 sudo lxc-stop -n galera2
 sudo lxc-stop -n galera3
+sudo lxc-stop -n haproxy
 
-echo "Destroying Galera containers..."
+echo "Destroying containers..."
 
 sudo lxc-destroy -n galera1
 sudo lxc-destroy -n galera2
 sudo lxc-destroy -n galera3
+sudo lxc-destroy -n haproxy
 
 echo "Removing any old LXC container known_hosts entries..."
 


### PR DESCRIPTION
A few cleanups, but most work around adding an LXC container housing
HAProxy. HAProxy is configured to balance traffic across the three
Galera LXC containers in a multi-writer as well as single-writer
scenario (as both scenarios will be tested in the eventual benchmarks).
